### PR TITLE
renamed publishing alias

### DIFF
--- a/src/TinkerwellSnippetsServiceProvider.php
+++ b/src/TinkerwellSnippetsServiceProvider.php
@@ -21,8 +21,8 @@ class TinkerwellSnippetsServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../config/config.php' => config_path('tinkerwell-snippets.php'),
-            ], 'config');
+                __DIR__ . '/../config/config.php' => config_path('tinkerwell-snippets.php'),
+            ], 'tinkerwell-snippets-config');
 
             // Publishing the views.
             /*$this->publishes([
@@ -31,8 +31,8 @@ class TinkerwellSnippetsServiceProvider extends ServiceProvider
 
             // Publishing assets.
             $this->publishes([
-                __DIR__.'/../resources/' => base_path('.tinkerwell/'),
-            ], 'assets');
+                __DIR__ . '/../resources/' => base_path('.tinkerwell/'),
+            ], 'tinkerwell-snippets-assets');
 
             // Publishing the translation files.
             /*$this->publishes([
@@ -50,7 +50,7 @@ class TinkerwellSnippetsServiceProvider extends ServiceProvider
     public function register()
     {
         // Automatically apply the package configuration
-        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'tinkerwell-snippets');
+        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'tinkerwell-snippets');
 
         // Register the main class to use with the facade
         $this->app->singleton('tinkerwell-snippets', function () {


### PR DESCRIPTION
Just solving what i had put as an issue here https://github.com/fwartner/laravel-tinkerwell-snippets/issues/1#issue-561758016

Given when developing Laravel apps, you will have a lot of config files so i think you had to specifically alias the config publishing from config to `tinkerwell-snippets-config` so that users do not have to guess which package they are publishing if its just `config`